### PR TITLE
Add support same collection join and array type foreing key

### DIFF
--- a/lib/joins.js
+++ b/lib/joins.js
@@ -89,7 +89,8 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 					// replace findOne with find
 					// replace filter with $in { field: { $in: [<value1>, <value2>, ... <valueN> ] } }
 
-					var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
+					// var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
+					var data = __original.find.call(coll, { _id: { $in: doc[join.foreignKey] } } , opt);
 					var container = join.containerField || coll._name + "_joined";
 					doc[container] = data;
 				}

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -24,7 +24,7 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
-		// console.log("findOne selector=", selector, " options=", options);
+		console.log("findOne selector=", selector, " options=", options);
 
 		var originalTransform = options.transform || null;
 
@@ -48,10 +48,10 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 
 				if (coll) {
 					var fk = doc[join.foreignKey];
-					var data = __original.findOne.call(coll, {
-						_id: fk
-					}, opt);
-					// console.log("fk=", fk, " data=", data);
+					var data = __original.find.call(coll, {
+						_id: { $in: fk }
+					}, opt).fetch();
+					console.log("fk=", fk, " data=", data);
 					var container = join.containerField || coll._name + "_joined";
 					doc[container] = data;
 				}

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -24,7 +24,7 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
-		console.log("findOne selector=", selector, " options=", options);
+		// console.log("findOne selector=", selector, " options=", options);
 
 		var originalTransform = options.transform || null;
 
@@ -51,7 +51,7 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 					var data = __original.findOne.call(coll, {
 						_id: fk
 					}, opt);
-					console.log("fk=", fk, " data=", data);
+					// console.log("fk=", fk, " data=", data);
 					var container = join.containerField || coll._name + "_joined";
 					doc[container] = data;
 				}
@@ -70,7 +70,7 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
-		console.log("find selector=", selector, " options=", options);
+		// console.log("find selector=", selector, " options=", options);
 
 		var originalTransform = options.transform || null;
 
@@ -103,18 +103,18 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 
 					var fkId = doc[join.foreignKey];
 					if (Array.isArray(fkId)) {
-						console.log("isArray is true fk=",fkId);
+						// console.log("isArray is true fk=",fkId);
 						var data = __original.find.call(coll, {_id: {$in: fkId} }, opt).fetch();
 						
 						var container = join.containerField || coll._name + "_joined";
 						doc[container] = data;
-						console.log("doc=",doc);
+						// console.log("doc=",doc);
 					}
 					else {
 						
-						console.log("pks=", fkId);
+						// console.log("pks=", fkId);
 						var data = __original.findOne.call(coll, {_id: fkId }, opt);
-						console.log("data=", data);
+						// console.log("data=", data);
 						var container = join.containerField || coll._name + "_joined";
 						doc[container] = data;
 					}
@@ -159,8 +159,6 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 	// cursors.push(cursor);
 
 
-
-
 	_.each(this._joins, function(join) {
 
 		if (join.collectionObject || join.collectionName) {
@@ -176,15 +174,15 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 			if (coll) {
 				var collectionName = coll._name;
 				var cursorName = cursor._cursorDescription.collectionName;
-				//console.log("cursors=",cursors);
-				//console.log(" cursor=",cur );
-				//console.log( "collection name=",coll._name );
-				//console.log( "cursor collectionName=",cursor._cursorDescription.collectionName );
+				//// console.log("cursors=",cursors);
+				//// console.log(" cursor=",cur );
+				//// console.log( "collection name=",coll._name );
+				//// console.log( "cursor collectionName=",cursor._cursorDescription.collectionName );
 
 				if (collectionName === cursorName) {
 					// it's the same collection, we should merge cursor selector with foreing ids
 
-					console.log("collectionName=", collectionName, " cursorName=", cursorName);
+					// console.log("collectionName=", collectionName, " cursorName=", cursorName);
 
 					var fks = cursor.map(function(doc) {
 						return doc[join.foreignKey];
@@ -200,7 +198,7 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 						}]
 					};
 
-					console.log("fks=", fks, " cursorSelector=", cursorSelector, " combinedSelector=", combinedSelector);
+					// console.log("fks=", fks, " cursorSelector=", cursorSelector, " combinedSelector=", combinedSelector);
 					var cur = coll.find(combinedSelector);
 
 					cursors.push(cur);
@@ -208,15 +206,21 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 				}
 				else {
 					// join from different collections, so we need to create new cursor for the other collection
+					// console.log("different collections, coll=",collectionName," cursor=",cursor);
 					cursors.push(cursor);
 					var ids = cursor.map(function(doc) {
-						return doc[join.foreignKey];
+						var a =  doc[join.foreignKey];
+				
+						return a;
 					});
+					ids = _.flatten(ids);
+					console.log("ids=",ids);
 					var cur = coll.find({
 						_id: {
-							$in: ids
+							$in: ids 
 						}
 					});
+					// console.log("cur=",cur);
 					cursors.push(cur);
 				}
 			}

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -140,9 +140,15 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 			}
 
 			if(coll) {
-				var ids = cursor.map(function(doc) { return doc[join.foreignKey]; });
-				var cur = coll.find({ _id: { $in: ids }});
-				cursors.push(cur);
+				var cursorColl = cursor.collection.name;
+				if( cursorColl === coll.name ) {
+					// it's the same collection, we should merge filter options
+					console.log(cursor);
+				} else {
+					var ids = cursor.map(function(doc) { return doc[join.foreignKey]; });
+					var cur = coll.find({ _id: { $in: ids }});
+					cursors.push(cur);
+				}
 			}
 
 		} else if(join.collectionNameField) {

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -48,8 +48,14 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 
 				if (coll) {
 					var fk = doc[join.foreignKey];
+					if (Array.isArray(fk) == false) {
+						fk = [fk];
+					}
+
 					var data = __original.find.call(coll, {
-						_id: { $in: fk }
+						_id: {
+							$in: fk
+						}
 					}, opt).fetch();
 					console.log("fk=", fk, " data=", data);
 					var container = join.containerField || coll._name + "_joined";
@@ -70,7 +76,7 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
-		// console.log("find selector=", selector, " options=", options);
+		console.log("find selector=", selector, " options=", options);
 
 		var originalTransform = options.transform || null;
 
@@ -103,27 +109,37 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 
 					var fkId = doc[join.foreignKey];
 					if (Array.isArray(fkId)) {
-						// console.log("isArray is true fk=",fkId);
-						var data = __original.find.call(coll, {_id: {$in: fkId} }, opt).fetch();
-						
+						console.log("isArray is true fk=", fkId);
+						var data = __original.find.call(coll, {
+							_id: {
+								$in: fkId
+							}
+						}, opt).fetch();
+						// console.log("data=",data);
 						var container = join.containerField || coll._name + "_joined";
 						doc[container] = data;
 						// console.log("doc=",doc);
 					}
 					else {
-						
-						// console.log("pks=", fkId);
-						var data = __original.findOne.call(coll, {_id: fkId }, opt);
+
+						console.log("pks=", fkId);
+						var data = __original.findOne.call(coll, {
+							_id: fkId
+						}, opt);
 						// console.log("data=", data);
 						var container = join.containerField || coll._name + "_joined";
 						doc[container] = data;
+						// console.log("doc=",doc);
+
+
 					}
-					
-					
+
+
 
 
 				}
 			});
+
 			if (originalTransform)
 				return originalTransform(doc);
 			else
@@ -154,13 +170,14 @@ Mongo.Collection.prototype.genericJoin = function(collectionNameField, foreignKe
 	this.doJoin(null, "", collectionNameField, foreignKey, containerField, []);
 };
 
+
+
 Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
-	var cursors = [];
-	// cursors.push(cursor);
-
-
+	// console.log("publishJoinedCursors");
+	var mapOfCursors = {};
+	var cursorCollectionName = cursor._cursorDescription.collectionName;
 	_.each(this._joins, function(join) {
-
+		debugger;
 		if (join.collectionObject || join.collectionName) {
 			var coll = null;
 
@@ -170,25 +187,43 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 			else {
 				coll = globalContext[join.collectionName];
 			}
-
 			if (coll) {
 				var collectionName = coll._name;
-				var cursorName = cursor._cursorDescription.collectionName;
-				//// console.log("cursors=",cursors);
-				//// console.log(" cursor=",cur );
-				//// console.log( "collection name=",coll._name );
-				//// console.log( "cursor collectionName=",cursor._cursorDescription.collectionName );
-
-				if (collectionName === cursorName) {
-					// it's the same collection, we should merge cursor selector with foreing ids
-
-					// console.log("collectionName=", collectionName, " cursorName=", cursorName);
-
+				var oldCursor = mapOfCursors[collectionName];
+				if (oldCursor == null) {
+					mapOfCursors[collectionName] = cursor;
+					var ids = cursor.map(function(doc) {
+						var a = doc[join.foreignKey];
+						return a;
+					});
+					if (Array.isArray(ids)) {
+						ids = _.flatten(ids);
+					}
+					else {
+						ids = [ids];
+					}
+					var cur = coll.find({
+						_id: {
+							$in: ids
+						}
+					});
+					mapOfCursors[coll._name] = cur;
+				}
+				else {
+					// do the joining, now oldCursor is pg and cursor is pg also
 					var fks = cursor.map(function(doc) {
-						return doc[join.foreignKey];
+						var a = doc[join.foreignKey];
+						return a;
 					});
 
-					var cursorSelector = cursor._cursorDescription.selector;
+					if (Array.isArray(fks)) {
+						fks = _.flatten(fks);
+					}
+					else {
+						fks = [fks];
+					}
+
+					var cursorSelector = oldCursor._cursorDescription.selector;
 
 					var combinedSelector = {
 						$or: [cursorSelector, {
@@ -198,63 +233,42 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 						}]
 					};
 
-					// console.log("fks=", fks, " cursorSelector=", cursorSelector, " combinedSelector=", combinedSelector);
+					console.log("fks=", fks, " cursorSelector=", cursorSelector, " combinedSelector=", combinedSelector);
 					var cur = coll.find(combinedSelector);
-
-					cursors.push(cur);
-
-				}
-				else {
-					// join from different collections, so we need to create new cursor for the other collection
-					// console.log("different collections, coll=",collectionName," cursor=",cursor);
-					cursors.push(cursor);
-					var ids = cursor.map(function(doc) {
-						var a =  doc[join.foreignKey];
-				
-						return a;
-					});
-					ids = _.flatten(ids);
-					console.log("ids=",ids);
-					var cur = coll.find({
-						_id: {
-							$in: ids 
-						}
-					});
-					// console.log("cur=",cur);
-					cursors.push(cur);
+					mapOfCursors[coll._name] = cur;
 				}
 			}
-
 		}
-		else if (join.collectionNameField) {
-			var data = cursor.map(function(doc) {
-				var res = {};
-				res[join.collectionNameField] = doc[join.collectionNameField];
-				res[join.foreignKey] = doc[join.foreignKey];
-				return res;
-			});
 
-			var collectionNames = _.uniq(_.map(data, function(doc) {
-				return doc[join.collectionNameField];
-			}));
-			_.each(collectionNames, function(collectionName) {
-				var coll = globalContext[collectionName];
-				if (coll) {
-					var ids = _.map(_.filter(data, function(doc) {
-						return doc[join.collectionNameField] === collectionName;
-					}), function(el) {
-						return el[join.foreignKey];
-					});
-					var cur = coll.find({
-						_id: {
-							$in: ids
-						}
-					});
-					cursors.push(cur);
-				}
-			});
+		else if (join.collectionNameField) {
+			console.log("join.collectionNameField=", join.collectionNameField);
+
 		}
 	});
+
+	if (mapOfCursors[cursorCollectionName] != null) {
+		// console.log("collection already found in map");
+		var oldCursor = mapOfCursors[cursorCollectionName];
+
+		var cursorSelector = cursor._cursorDescription.selector;
+		var oldCursorSelector = oldCursor._cursorDescription.selector;
+		
+		var combinedSelector = {
+			$or: [cursorSelector, oldCursorSelector]
+		};
+
+		oldCursor._cursorDescription.selector = combinedSelector;
+		
+		mapOfCursors[cursorCollectionName] = oldCursor;
+		
+	}
+	else {
+		// console.log("collection NOT found in map");
+		mapOfCursors[cursorCollectionName] = cursor;
+	}
+
+	var cursors = _.values(mapOfCursors);
+	// console.log("cursors=", cursors);
 
 	return cursors;
 };

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -85,6 +85,10 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 					coll = globalContext[doc[join.collectionNameField]];
 
 				if(coll) {
+					// HERE, add support for array of foreingKey
+					// replace findOne with find
+					// replace filter with $in { field: { $in: [<value1>, <value2>, ... <valueN> ] } }
+
 					var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
 					var container = join.containerField || coll._name + "_joined";
 					doc[container] = data;

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -177,7 +177,6 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 	var mapOfCursors = {};
 	var cursorCollectionName = cursor._cursorDescription.collectionName;
 	_.each(this._joins, function(join) {
-		debugger;
 		if (join.collectionObject || join.collectionName) {
 			var coll = null;
 

--- a/lib/joins.js
+++ b/lib/joins.js
@@ -24,12 +24,14 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
+		console.log("findOne selector=", selector, " options=", options);
+
 		var originalTransform = options.transform || null;
 
 		options.transform = function(doc) {
 			_.each(self._joins, function(join) {
 				var opt = {};
-				if(join.fieldList && join.fieldList.length) {
+				if (join.fieldList && join.fieldList.length) {
 					opt.fields = {};
 					_.each(join.fieldList, function(field) {
 						opt.fields[field] = 1;
@@ -37,20 +39,24 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 				}
 
 				var coll = null;
-				if(join.collectionObject)
+				if (join.collectionObject)
 					coll = join.collectionObject;
-				else if(join.collectionName)
+				else if (join.collectionName)
 					coll = globalContext[join.collectionName];
-				else if(join.collectionNameField)
+				else if (join.collectionNameField)
 					coll = globalContext[doc[join.collectionNameField]];
 
-				if(coll) {
-					var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
+				if (coll) {
+					var fk = doc[join.foreignKey];
+					var data = __original.findOne.call(coll, {
+						_id: fk
+					}, opt);
+					console.log("fk=", fk, " data=", data);
 					var container = join.containerField || coll._name + "_joined";
 					doc[container] = data;
 				}
 			});
-			if(originalTransform) 
+			if (originalTransform)
 				return originalTransform(doc);
 			else
 				return doc;
@@ -64,12 +70,14 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 		selector = selector || {};
 		options = options || {};
 
+		console.log("find selector=", selector, " options=", options);
+
 		var originalTransform = options.transform || null;
 
 		options.transform = function(doc) {
 			_.each(self._joins, function(join) {
 				var opt = {};
-				if(join.fieldList && join.fieldList.length) {
+				if (join.fieldList && join.fieldList.length) {
 					opt.fields = {};
 					_.each(join.fieldList, function(field) {
 						opt.fields[field] = 1;
@@ -77,25 +85,46 @@ Mongo.Collection.prototype.doJoin = function(collectionObject, collectionName, c
 				}
 
 				var coll = null;
-				if(join.collectionObject)
+				if (join.collectionObject)
 					coll = join.collectionObject;
-				else if(join.collectionName)
+				else if (join.collectionName)
 					coll = globalContext[join.collectionName];
-				else if(join.collectionNameField)
+				else if (join.collectionNameField)
 					coll = globalContext[doc[join.collectionNameField]];
 
-				if(coll) {
+				if (coll) {
 					// HERE, add support for array of foreingKey
 					// replace findOne with find
-					// replace filter with $in { field: { $in: [<value1>, <value2>, ... <valueN> ] } }
+					// replace filter with $in { field: { $in: [<value1>, <value2>, ... <valueN> ] } }		
 
-					// var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
-					var data = __original.find.call(coll, { _id: { $in: doc[join.foreignKey] } } , opt);
-					var container = join.containerField || coll._name + "_joined";
-					doc[container] = data;
+					//var data = __original.findOne.call(coll, { _id: doc[join.foreignKey] }, opt);
+					// var data = __original.find.call(coll, { _id: { $in: doc[join.foreignKey] } } , opt);
+					//[ doc[join.foreignKey] ]
+
+					var fkId = doc[join.foreignKey];
+					if (Array.isArray(fkId)) {
+						console.log("isArray is true fk=",fkId);
+						var data = __original.find.call(coll, {_id: {$in: fkId} }, opt).fetch();
+						
+						var container = join.containerField || coll._name + "_joined";
+						doc[container] = data;
+						console.log("doc=",doc);
+					}
+					else {
+						
+						console.log("pks=", fkId);
+						var data = __original.findOne.call(coll, {_id: fkId }, opt);
+						console.log("data=", data);
+						var container = join.containerField || coll._name + "_joined";
+						doc[container] = data;
+					}
+					
+					
+
+
 				}
 			});
-			if(originalTransform) 
+			if (originalTransform)
 				return originalTransform(doc);
 			else
 				return doc;
@@ -111,9 +140,10 @@ Mongo.Collection.prototype.join = function(collection, foreignKey, containerFiel
 	var collectionObject = null;
 	var collectionName = "";
 
-	if(_.isString(collection)) {
+	if (_.isString(collection)) {
 		collectionName = collection;
-	} else {
+	}
+	else {
 		collectionObject = collection;
 	}
 
@@ -126,32 +156,73 @@ Mongo.Collection.prototype.genericJoin = function(collectionNameField, foreignKe
 
 Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 	var cursors = [];
-	cursors.push(cursor);
+	// cursors.push(cursor);
+
+
+
 
 	_.each(this._joins, function(join) {
 
-		if(join.collectionObject || join.collectionName) {
+		if (join.collectionObject || join.collectionName) {
 			var coll = null;
 
-			if(join.collectionObject) {
+			if (join.collectionObject) {
 				coll = join.collectionObject;
-			} else {
+			}
+			else {
 				coll = globalContext[join.collectionName];
 			}
 
-			if(coll) {
-				var cursorColl = cursor.collection.name;
-				if( cursorColl === coll.name ) {
-					// it's the same collection, we should merge filter options
-					console.log(cursor);
-				} else {
-					var ids = cursor.map(function(doc) { return doc[join.foreignKey]; });
-					var cur = coll.find({ _id: { $in: ids }});
+			if (coll) {
+				var collectionName = coll._name;
+				var cursorName = cursor._cursorDescription.collectionName;
+				//console.log("cursors=",cursors);
+				//console.log(" cursor=",cur );
+				//console.log( "collection name=",coll._name );
+				//console.log( "cursor collectionName=",cursor._cursorDescription.collectionName );
+
+				if (collectionName === cursorName) {
+					// it's the same collection, we should merge cursor selector with foreing ids
+
+					console.log("collectionName=", collectionName, " cursorName=", cursorName);
+
+					var fks = cursor.map(function(doc) {
+						return doc[join.foreignKey];
+					});
+
+					var cursorSelector = cursor._cursorDescription.selector;
+
+					var combinedSelector = {
+						$or: [cursorSelector, {
+							_id: {
+								$in: fks
+							}
+						}]
+					};
+
+					console.log("fks=", fks, " cursorSelector=", cursorSelector, " combinedSelector=", combinedSelector);
+					var cur = coll.find(combinedSelector);
+
+					cursors.push(cur);
+
+				}
+				else {
+					// join from different collections, so we need to create new cursor for the other collection
+					cursors.push(cursor);
+					var ids = cursor.map(function(doc) {
+						return doc[join.foreignKey];
+					});
+					var cur = coll.find({
+						_id: {
+							$in: ids
+						}
+					});
 					cursors.push(cur);
 				}
 			}
 
-		} else if(join.collectionNameField) {
+		}
+		else if (join.collectionNameField) {
 			var data = cursor.map(function(doc) {
 				var res = {};
 				res[join.collectionNameField] = doc[join.collectionNameField];
@@ -159,17 +230,27 @@ Mongo.Collection.prototype.publishJoinedCursors = function(cursor) {
 				return res;
 			});
 
-			var collectionNames = _.uniq(_.map(data, function(doc) { return doc[join.collectionNameField]; }));
+			var collectionNames = _.uniq(_.map(data, function(doc) {
+				return doc[join.collectionNameField];
+			}));
 			_.each(collectionNames, function(collectionName) {
 				var coll = globalContext[collectionName];
-				if(coll) {
-					var ids = _.map(_.filter(data, function(doc) { return doc[join.collectionNameField] === collectionName; }), function(el) { return el[join.foreignKey]; });
-					var cur = coll.find({ _id: { $in: ids }});
+				if (coll) {
+					var ids = _.map(_.filter(data, function(doc) {
+						return doc[join.collectionNameField] === collectionName;
+					}), function(el) {
+						return el[join.foreignKey];
+					});
+					var cur = coll.find({
+						_id: {
+							$in: ids
+						}
+					});
 					cursors.push(cur);
 				}
 			});
 		}
-	});		
+	});
 
-	return cursors;	
+	return cursors;
 };

--- a/package.js
+++ b/package.js
@@ -1,7 +1,8 @@
 Package.describe({
 	summary: "Generic joins for Meteor",
-	version: "1.0.6",
-	git: "https://github.com/perak/meteor-joins.git"
+	version: "1.0.7",
+	git: "https://github.com/perak/meteor-joins.git",
+	name: "perak:joins"
 });
 
 Package.onUse(function (api) {

--- a/smart.json
+++ b/smart.json
@@ -3,7 +3,7 @@
 	"description": "Generic joins for Meteor",
 	"homepage": "https://github.com/perak/meteor-joins",
 	"author": "Petar Korponaic",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"git": "https://github.com/perak/meteor-joins.git",
 	"packages": {}
 }


### PR DESCRIPTION
First pull request for discussion. Still contains debug logs and some formatting issues.

1) Add support to have joins the same collection where the field is. This is usefull so that one can build a master-parent tree. 

2) Support field type of array ( used in multi select  )
